### PR TITLE
Fix project page cleanup: title typo, stale comment, redundant link, draft typo

### DIFF
--- a/content/projects/devsecops-proj.md
+++ b/content/projects/devsecops-proj.md
@@ -16,7 +16,7 @@ tags:
 
 link: "https://github.com/sagarkpanda/devsecops-labs"
 # blogLink: "/blogs/k8s/k8s-monitoring"
-drfat: false
+draft: false
 ---
 
 <!-- Body content pending -- Sagar will write this. -->

--- a/content/projects/k8s-otel-proj.md
+++ b/content/projects/k8s-otel-proj.md
@@ -1,5 +1,5 @@
 ---
-title: "Kubernetes Observabitily with AI"
+title: "Kubernetes Observability"
 date: 2026-06-20
 summary: "GitOps infrastructure and Kubernetes platform for an OpenTelemetry observability demo, provisioned on Amazon EKS."
 status: "completed"
@@ -14,7 +14,6 @@ blogLink: "otel-on-eks"
 draft: false
 ---
 
-<!-- Body content pending -- Sagar will write this. -->
 ## OTel Labs Platform – OpenTelemetry on EKS: End-to-End Observability
 
 
@@ -304,8 +303,4 @@ kube-state-metrics
 ```
 
 This telemetry is exported together with application telemetry to both observability backends.
-
-
-[Check out the full project]({{< relref "otel-on-eks" >}})
-<!-- [{{< icon name="posts" size="lg" >}} Check out the full project]({{< relref "otel-on-eks" >}}) -->
 

--- a/content/projects/k8s-otel-proj.md
+++ b/content/projects/k8s-otel-proj.md
@@ -1,5 +1,5 @@
 ---
-title: "Kubernetes Observability"
+title: "Kubernetes Observability with AI"
 date: 2026-06-20
 summary: "GitOps infrastructure and Kubernetes platform for an OpenTelemetry observability demo, provisioned on Amazon EKS."
 status: "completed"


### PR DESCRIPTION
Fixes 4 small issues found while reviewing the project pages:

- **k8s-otel-proj.md**: title typo ("Kubernetes Observabitily with AI" → "Kubernetes Observability"), removed a stale "body content pending" comment (the body is fully written), removed a redundant link at the end of the body duplicating the "Read the Blog" button
- **devsecops-proj.md**: fixed `drfat: false` → `draft: false` (the typo meant the field was silently ignored)

No template/CSS changes, content-only.